### PR TITLE
Add sign-in and sign-up pages to fix dashboard route protection

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div className="flex justify-center items-center min-h-[80vh]">
+      <SignIn />
+    </div>
+  );
+}

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div className="flex justify-center items-center min-h-[80vh]">
+      <SignUp />
+    </div>
+  );
+}


### PR DESCRIPTION
Without dedicated /sign-in and /sign-up pages, Clerk's auth.protect() in middleware would redirect unauthenticated users to a 404. These pages complete the auth flow so /dashboard and all sub-routes are properly protected.