### PR TITLE
feat: enable dark mode site-wide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >


### PR DESCRIPTION
Add 'dark' class to html element to force dark mode across the entire site. The dark mode CSS variables were already defined in globals.css.