### PR TITLE
Add Cancel button beside Save Changes and redirect to dashboard

### DIFF
--- a/src/app/dashboard/workout/[workoutId]/EditWorkoutForm.tsx
+++ b/src/app/dashboard/workout/[workoutId]/EditWorkoutForm.tsx
@@ -150,13 +150,24 @@ export default function EditWorkoutForm({ workoutId, defaultValues }: Props) {
           </Button>
         </div>
 
-        <Button
-          type="submit"
-          className="w-full"
-          disabled={form.formState.isSubmitting}
-        >
-          {form.formState.isSubmitting ? "Saving..." : "Save Changes"}
-        </Button>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1"
+            onClick={() => router.push("/dashboard")}
+            disabled={form.formState.isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            className="flex-1"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Saving..." : "Save Changes"}
+          </Button>
+        </div>
       </form>
     </Form>
   );


### PR DESCRIPTION
Fixes #16

- "Save Changes" button already redirected to dashboard on submit (working correctly)
- Added a "Cancel" button beside "Save Changes" that navigates back to /dashboard without saving
- Both buttons displayed side by side with equal width

Generated with [Claude Code](https://claude.ai/code)